### PR TITLE
Add unit test for `wire->internal` purchase list adapter

### DIFF
--- a/test/unit/purchase_listinator/adapters/in/purchase_list_test.clj
+++ b/test/unit/purchase_listinator/adapters/in/purchase_list_test.clj
@@ -1,0 +1,20 @@
+(ns purchase-listinator.adapters.in.purchase-list-test
+  (:require [clojure.test :refer :all]
+            [purchase-listinator.adapters.in.purchase-list :as adapters.in.purchase-list]
+            [schema.test :as s]))
+
+(def wire-purchase-list
+  {:name        "random name"
+   :id          "f948399f-29c3-402e-81ed-b0d695fc792a"
+   :enabled     true
+   :in-progress true
+   :status      :in-progress})
+
+(s/deftest wire->internal-test
+  (testing "That we can internalize a purchase list from the wire"
+    (is (= {:enabled     true
+            :id          #uuid "f948399f-29c3-402e-81ed-b0d695fc792a"
+            :in-progress true
+            :name        "random name"
+            :status      :in-progress}
+           (adapters.in.purchase-list/wire->internal wire-purchase-list)))))


### PR DESCRIPTION
Just adding unit test for `purchase-listinator.adapters.in.purchase-list-test` namespace.