### PR TITLE
Start receiving purchase list events in the shopping cart

### DIFF
--- a/src/purchase_listinator/adapters/in/shopping_purchase_list_events.clj
+++ b/src/purchase_listinator/adapters/in/shopping_purchase_list_events.clj
@@ -1,0 +1,11 @@
+(ns purchase-listinator.adapters.in.shopping-purchase-list-events
+  (:require [schema.core :as s]
+            [purchase-listinator.models.internal.shopping-cart :as models.internal.shopping-cart]
+            [purchase-listinator.wires.in.purchase-category-events :as wires.in.purchase-category-events]))
+
+(s/defn category-deleted-event->internal :- models.internal.shopping-cart/PurchaseListCategoryDeleted
+  [wire :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent
+   moment :- s/Num]
+  (assoc wire
+    :event-type :purchase-list-category-deleted
+    :moment moment))

--- a/src/purchase_listinator/adapters/in/shopping_purchase_list_events.clj
+++ b/src/purchase_listinator/adapters/in/shopping_purchase_list_events.clj
@@ -4,8 +4,9 @@
             [purchase-listinator.wires.in.purchase-category-events :as wires.in.purchase-category-events]))
 
 (s/defn category-deleted-event->internal :- models.internal.shopping-cart/PurchaseListCategoryDeleted
-  [wire :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent
-   moment :- s/Num]
-  (assoc wire
-    :event-type :purchase-list-category-deleted
-    :moment moment))
+  [wire :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent]
+  (assoc wire :event-type :purchase-list-category-deleted))
+
+(s/defn category-created-event->internal :- models.internal.shopping-cart/PurchaseListCategoryCreated
+  [wire :- wires.in.purchase-category-events/PurchaseCategoryCreatedEvent]
+  (assoc wire :event-type :purchase-list-category-created))

--- a/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
+++ b/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
@@ -9,3 +9,11 @@
   {:category-id      id
    :purchase-list-id purchase-list-id
    :moment           moment})
+
+(s/defn ->CategoryCreatedEvent :- wires.out.purchase-list-caegory-events/CategoryCreatedEvent
+  [{:keys [id] :as wire} :- models.internal.purchase-category/PurchaseCategory
+   moment :- s/Num]
+  (-> wire
+      (assoc :moment moment
+             :category-id id)
+      (dissoc :id)))

--- a/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
+++ b/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
@@ -1,7 +1,7 @@
 (ns purchase-listinator.adapters.out.purchase-list-category-events
   (:require [schema.core :as s]
             [purchase-listinator.models.internal.purchase-category :as models.internal.purchase-category]
-            [purchase-listinator.wires.out.purchase-list-caegory-events :as wires.out.purchase-list-caegory-events]))
+            [purchase-listinator.wires.out.purchase-list-category-events :as wires.out.purchase-list-caegory-events]))
 
 (s/defn ->CategoryDeletedEvent :- wires.out.purchase-list-caegory-events/CategoryDeletedEvent
   [{:keys [id purchase-list-id]} :- models.internal.purchase-category/PurchaseCategory

--- a/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
+++ b/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
@@ -1,0 +1,9 @@
+(ns purchase-listinator.adapters.out.purchase-list-category-events
+  (:require [schema.core :as s]
+            [purchase-listinator.models.internal.purchase-category :as models.internal.purchase-category]
+            [purchase-listinator.wires.out.purchase-list-caegory-events :as wires.out.purchase-list-caegory-events]))
+
+(s/defn ->CategoryDeletedEvent :- wires.out.purchase-list-caegory-events/CategoryDeletedEvent
+  [{:keys [id purchase-list-id]} :- models.internal.purchase-category/PurchaseCategory]
+  {:category-id      id
+   :purchase-list-id purchase-list-id})

--- a/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
+++ b/src/purchase_listinator/adapters/out/purchase_list_category_events.clj
@@ -4,6 +4,8 @@
             [purchase-listinator.wires.out.purchase-list-caegory-events :as wires.out.purchase-list-caegory-events]))
 
 (s/defn ->CategoryDeletedEvent :- wires.out.purchase-list-caegory-events/CategoryDeletedEvent
-  [{:keys [id purchase-list-id]} :- models.internal.purchase-category/PurchaseCategory]
+  [{:keys [id purchase-list-id]} :- models.internal.purchase-category/PurchaseCategory
+   moment :- s/Num]
   {:category-id      id
-   :purchase-list-id purchase-list-id})
+   :purchase-list-id purchase-list-id
+   :moment           moment})

--- a/src/purchase_listinator/components/rabbitmq.clj
+++ b/src/purchase_listinator/components/rabbitmq.clj
@@ -57,7 +57,8 @@
                (->rabbitmq exchange)
                ""
                (misc.content-type-parser/transform-content-to payload content-type)
-               content-type)))
+               content-type)
+   payload))
 
 (defrecord RabbitMq [config]
   component/Lifecycle

--- a/src/purchase_listinator/components/rabbitmq.clj
+++ b/src/purchase_listinator/components/rabbitmq.clj
@@ -8,10 +8,10 @@
             [com.stuartsierra.component :as component]
             [purchase-listinator.endpoints.queue.shopping-purchase-list-event-received :as endpoints.queue.shopping-purchase-list-event-received]
             [purchase-listinator.misc.content-type-parser :as misc.content-type-parser]
-            [cheshire.core :as cheshire]
             [schema.core :as s]
             [clojure.data.json :as json]
-            [camel-snake-kebab.core :as csk]))
+            [camel-snake-kebab.core :as csk]
+            [schema.coerce :as coerce]))
 
 (def subscribers (concat
                    endpoints.queue.shopping-purchase-list-event-received/subscribers))
@@ -22,6 +22,7 @@
 
 (s/defn consumer-base
   [components
+   schema
    consumer
    channel
    metadata
@@ -30,16 +31,18 @@
         map-data (json/read-str data :key-fn csk/->kebab-case-keyword)
         map-data (if (string? map-data)
                    (json/read-str map-data :key-fn csk/->kebab-case-keyword) ;I don't know why I need to do it the second time
-                   map-data)]
-    (consumer channel metadata components map-data)))
+                   map-data)
+        coerce-function (if schema (coerce/coercer schema coerce/json-coercion-matcher) identity)
+        coerced-data (coerce-function map-data)]
+    (consumer channel metadata components coerced-data)))
 
 (defn start-consumer
   [ch
    components
-   {:keys [exchange queue handler]}]
+   {:keys [exchange queue schema handler]}]
   (lq/declare ch (->rabbitmq queue) {:exclusive false :auto-delete false})
   (lq/bind ch (->rabbitmq queue) (->rabbitmq exchange))
-  (lc/subscribe ch (->rabbitmq queue) (partial consumer-base components handler) {:auto-ack true}))
+  (lc/subscribe ch (->rabbitmq queue) (partial consumer-base components schema handler) {:auto-ack true}))
 
 (s/defn publish
   ([channel
@@ -70,7 +73,7 @@
       (assoc this
         :connection conn
         :channel ch
-        :publish publish)))
+        :publish (partial publish ch))))
   (stop [this]
     (rmq/close (:channel this))
     (rmq/close (:connection this))

--- a/src/purchase_listinator/core.clj
+++ b/src/purchase_listinator/core.clj
@@ -28,7 +28,7 @@
 (def system-config
   {:env        :prod
    :web-server {:port 5150
-                :host "192.168.1.102"}
+                :host "192.168.1.104"}
    :mongo      {:port    27017
                 :host    "localhost"
                 :db-name "monger-test"}

--- a/src/purchase_listinator/dbs/datomic/purchase_list.clj
+++ b/src/purchase_listinator/dbs/datomic/purchase_list.clj
@@ -25,6 +25,7 @@
 
 (s/defn ^:private transact
   [connection & purchases-lists]
+  (println purchases-lists)
   @(d/transact connection purchases-lists))
 
 (s/defn get-enabled

--- a/src/purchase_listinator/dbs/datomic/purchase_list.clj
+++ b/src/purchase_listinator/dbs/datomic/purchase_list.clj
@@ -26,7 +26,6 @@
 
 (s/defn ^:private transact
   [connection & purchases-lists]
-  (println purchases-lists)
   @(d/transact connection purchases-lists))
 
 (s/defn get-enabled

--- a/src/purchase_listinator/endpoints/http/purchase_list.clj
+++ b/src/purchase_listinator/endpoints/http/purchase_list.clj
@@ -59,11 +59,11 @@
           misc.http/->Success))
 
 (s/defn add-purchases-lists-category
-  [{{datomic :datomic} :component
+  [{components :component
     wire               :json-params}]
   (branch (misc.either/try-right
             (let [category (adapters.in.purchase-category/wire->internal wire)]
-              (flows.purchase-category/create category datomic)))
+              (flows.purchase-category/create category components)))
           misc.http/->Error
           misc.http/->Success))
 

--- a/src/purchase_listinator/endpoints/http/purchase_list.clj
+++ b/src/purchase_listinator/endpoints/http/purchase_list.clj
@@ -120,11 +120,11 @@
                         (flows.purchase-item/edit-name new-name datomic)))))
 
 (s/defn delete-purchases-lists-category
-  [{{:keys [datomic]} :component
+  [{{:keys [datomic rabbitmq]} :component
     {:keys [id]}      :path-params}]
   (misc.http/default-branch (misc.either/try-right
                     (-> (adapters.misc/string->uuid id)
-                        (flows.purchase-category/delete datomic)))))
+                        (flows.purchase-category/delete datomic rabbitmq)))))
 
 (s/defn edit-category
   [{{:keys [datomic]} :component

--- a/src/purchase_listinator/endpoints/http/purchase_list.clj
+++ b/src/purchase_listinator/endpoints/http/purchase_list.clj
@@ -60,12 +60,11 @@
 
 (s/defn add-purchases-lists-category
   [{components :component
-    wire               :json-params}]
-  (branch (misc.either/try-right
-            (let [category (adapters.in.purchase-category/wire->internal wire)]
-              (flows.purchase-category/create category components)))
-          misc.http/->Error
-          misc.http/->Success))
+    wire       :json-params}]
+  (misc.http/default-branch
+    (misc.either/try-right
+      (-> (adapters.in.purchase-category/wire->internal wire)
+          (flows.purchase-category/create components)))))
 
 (s/defn change-category-order
   [{{datomic :datomic}        :component
@@ -101,37 +100,38 @@
   [{{:keys [datomic]}         :component
     {:keys [id new-quantity]} :path-params}]
   (misc.http/default-branch (misc.either/try-right
-                    (let [new-quantity (adapters.misc/string->integer new-quantity)
-                          item-id (adapters.misc/string->uuid id)]
-                      (flows.purchase-item/change-item-quantity item-id new-quantity datomic)))))
+                              (let [new-quantity (adapters.misc/string->integer new-quantity)
+                                    item-id (adapters.misc/string->uuid id)]
+                                (flows.purchase-item/change-item-quantity item-id new-quantity datomic)))))
 
 (s/defn delete-purchases-lists-item
   [{{:keys [datomic]} :component
     {:keys [id]}      :path-params}]
   (misc.http/default-branch (misc.either/try-right
-                    (-> (adapters.misc/string->uuid id)
-                        (flows.purchase-item/delete datomic)))))
+                              (-> (adapters.misc/string->uuid id)
+                                  (flows.purchase-item/delete datomic)))))
 
 (s/defn edit-item-name
   [{{:keys [datomic]}     :component
     {:keys [id new-name]} :path-params}]
   (misc.http/default-branch (misc.either/try-right
-                    (-> (adapters.misc/string->uuid id)
-                        (flows.purchase-item/edit-name new-name datomic)))))
+                              (-> (adapters.misc/string->uuid id)
+                                  (flows.purchase-item/edit-name new-name datomic)))))
 
 (s/defn delete-purchases-lists-category
   [{{:keys [datomic rabbitmq]} :component
-    {:keys [id]}      :path-params}]
-  (misc.http/default-branch (misc.either/try-right
-                    (-> (adapters.misc/string->uuid id)
-                        (flows.purchase-category/delete datomic rabbitmq)))))
+    {:keys [id]}               :path-params}]
+  (misc.http/default-branch
+    (misc.either/try-right
+      (-> (adapters.misc/string->uuid id)
+          (flows.purchase-category/delete datomic rabbitmq)))))
 
 (s/defn edit-category
   [{{:keys [datomic]} :component
     wire              :json-params}]
   (misc.http/default-branch (misc.either/try-right
-                    (-> (adapters.in.purchase-category/wire->internal wire)
-                        (flows.purchase-category/edit datomic)))))
+                              (-> (adapters.in.purchase-category/wire->internal wire)
+                                  (flows.purchase-category/edit datomic)))))
 
 ;todo: /lists should return only the purchase list data and /lists/:id should return items and categories too
 (def routes

--- a/src/purchase_listinator/endpoints/http/shopping.clj
+++ b/src/purchase_listinator/endpoints/http/shopping.clj
@@ -45,7 +45,6 @@
   (misc.http/default-branch
     (misc.either/try-right
       (let [now (misc.date/numb-now)
-
             cart-event (adapters.in.shopping-cart-event/wire->internal wire now)]
         (flows.shopping/receive-cart-event cart-event component)))))
 

--- a/src/purchase_listinator/endpoints/queue/shopping_purchase_list_event_received.clj
+++ b/src/purchase_listinator/endpoints/queue/shopping_purchase_list_event_received.clj
@@ -1,15 +1,29 @@
-(ns purchase-listinator.endpoints.queue.shopping-purchase-list-event-received)
+(ns purchase-listinator.endpoints.queue.shopping-purchase-list-event-received
+  (:require [purchase-listinator.wires.in.purchase-category-events :as wires.in.purchase-category-events]
+            [schema.core :as s]))
 
 (defn purchase-list-event-received
-  [channel
-   _
+  [_channel
+   _metadata
    components
    payload]
   (println payload)
   (println "components")
   (println (keys components)))
 
+(s/defn purchase-list-category-deleted-event-received
+  [_channel
+   _metadata
+   components
+   {:keys [category-id purchase-list-id]} :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent]
+  (println category-id)
+  (println purchase-list-id))
+
 (def subscribers
   [{:exchange :purchase-listinator/purchase-list.updated
     :queue   :purchase-listinator/shopping-list.update
-    :handler purchase-list-event-received}])
+    :handler purchase-list-event-received}
+   {:exchange :purchase-listinator/purchase-list.category.deleted
+    :queue   :purchase-listinator/shopping-list.category.delete
+    :schema wires.in.purchase-category-events/PurchaseCategoryDeletedEvent
+    :handler purchase-list-category-deleted-event-received}])

--- a/src/purchase_listinator/endpoints/queue/shopping_purchase_list_event_received.clj
+++ b/src/purchase_listinator/endpoints/queue/shopping_purchase_list_event_received.clj
@@ -18,10 +18,17 @@
   [_channel
    _metadata
    components
-   {:keys [moment] :as event} :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent]
-  (-> (adapters.in.shopping-purchase-list-events/category-deleted-event->internal event moment)
+   event :- wires.in.purchase-category-events/PurchaseCategoryDeletedEvent]
+  (-> (adapters.in.shopping-purchase-list-events/category-deleted-event->internal event)
       (flows.shopping/receive-cart-event-by-list components)))
 
+(s/defn purchase-list-category-created-event-received
+  [_channel
+   _metadata
+   components
+   event :- wires.in.purchase-category-events/PurchaseCategoryCreatedEvent]
+  (-> (adapters.in.shopping-purchase-list-events/category-created-event->internal event)
+      (flows.shopping/receive-cart-event-by-list components)))
 
 (def subscribers
   [{:exchange :purchase-listinator/purchase-list.updated
@@ -30,4 +37,10 @@
    {:exchange :purchase-listinator/purchase-list.category.deleted
     :queue    :purchase-listinator/shopping-list.category.delete
     :schema   wires.in.purchase-category-events/PurchaseCategoryDeletedEvent
-    :handler  purchase-list-category-deleted-event-received}])
+    :handler  purchase-list-category-deleted-event-received}
+   {:exchange :purchase-listinator/purchase-list.category.created
+    :queue    :purchase-listinator/shopping-list.category.create
+    :schema   wires.in.purchase-category-events/PurchaseCategoryCreatedEvent
+    :handler  purchase-list-category-created-event-received}])
+
+

--- a/src/purchase_listinator/flows/purchase_category.clj
+++ b/src/purchase_listinator/flows/purchase_category.clj
@@ -10,14 +10,16 @@
 
 (s/defn create
   [{:keys [name purchase-list-id] :as category} :- models.internal.purchase-category/PurchaseCategory
-   datomic]
+   {:keys [datomic rabbitmq]}]
   (either/try-right
     (if (datomic.purchase-category/get-by-name purchase-list-id name datomic)
       (left {:status 400
              :error  {:message "[[CATEGORY_WITH_THE_SAME_NAME_ALREADY_EXISTENT]]"}})
       (let [new-category (-> (datomic.purchase-category/categories-count purchase-list-id datomic)
                              (logic.reposition/change-order-position category))]
-        (datomic.purchase-category/upsert new-category datomic)))))
+        (datomic.purchase-category/upsert new-category datomic)
+        (publishers.purchase-list-category/category-created new-category rabbitmq)
+        new-category))))
 
 (s/defn edit
   [{:keys [name color id]} :- models.internal.purchase-category/PurchaseCategory

--- a/src/purchase_listinator/flows/shopping.clj
+++ b/src/purchase_listinator/flows/shopping.clj
@@ -70,9 +70,12 @@
 (s/defn receive-cart-event-by-list
   [{:keys [purchase-list-id] :as event} :- models.internal.shopping-cart/CartEvent
    {:keys [redis datomic]}]
-  (some-> (datomic.shopping/get-in-progress-by-list-id purchase-list-id datomic)
-          :id
-          (redis.shopping-cart/find-cart redis)
-          (logic.shopping-cart-event/add-event event)
-          (redis.shopping-cart/upsert redis))
+  (try (some-> (datomic.shopping/get-in-progress-by-list-id purchase-list-id datomic)
+               :id
+               (redis.shopping-cart/find-cart redis)
+               (logic.shopping-cart-event/add-event event)
+               (redis.shopping-cart/upsert redis))
+       (catch Exception e
+         (println e)
+         (throw e)))
   event)

--- a/src/purchase_listinator/flows/shopping.clj
+++ b/src/purchase_listinator/flows/shopping.clj
@@ -47,8 +47,8 @@
   [shopping-id :- s/Uuid
    {:keys [datomic redis]}]
   (let [cart (redis.shopping-cart/find-cart shopping-id redis)
-        {:keys [list-id]} (datomic.shopping/get-by-id shopping-id datomic)
-        purchase-list (dbs.datomic.purchase-list/get-management-data list-id datomic)
+        {:keys [list-id date]} (datomic.shopping/get-by-id shopping-id datomic)
+        purchase-list (dbs.datomic.purchase-list/get-management-data list-id date datomic)
         shopping (logic.shopping/purchase-list->shopping-list shopping-id purchase-list)]
     (logic.shopping-cart-event/apply-cart cart shopping)))
 

--- a/src/purchase_listinator/flows/shopping.clj
+++ b/src/purchase_listinator/flows/shopping.clj
@@ -66,3 +66,13 @@
       (logic.shopping-cart-event/add-event event)
       (redis.shopping-cart/upsert redis))
   event)
+
+(s/defn receive-cart-event-by-list
+  [{:keys [purchase-list-id] :as event} :- models.internal.shopping-cart/CartEvent
+   {:keys [redis datomic]}]
+  (some-> (datomic.shopping/get-in-progress-by-list-id purchase-list-id datomic)
+          :id
+          (redis.shopping-cart/find-cart redis)
+          (logic.shopping-cart-event/add-event event)
+          (redis.shopping-cart/upsert redis))
+  event)

--- a/src/purchase_listinator/logic/purchase_list.clj
+++ b/src/purchase_listinator/logic/purchase_list.clj
@@ -8,7 +8,6 @@
   {:id          (misc.general/squuid)
    :enabled     true
    :in-progress false
-   :status      :waiting
    :name        name})
 
 (s/defn changed?

--- a/src/purchase_listinator/logic/shopping_cart_event.clj
+++ b/src/purchase_listinator/logic/shopping_cart_event.clj
@@ -105,6 +105,14 @@
       (reorder-item-same-category shopping old-category current-item-position new-position)
       (reorder-item-other-category shopping current-item old-category new-category new-position))))
 
+
+(s/defmethod ^:private apply-event :purchase-list-category-deleted :- models.internal.shopping-list/ShoppingList
+  [{:keys [category-id]} :- models.internal.shopping-cart/PurchaseListCategoryDeleted
+   {:keys [categories] :as shopping} :- models.internal.shopping-list/ShoppingList]
+  (->> categories
+       (filter #(not= (:id % category-id)))
+       (assoc shopping :categories)))
+
 (s/defmethod ^:private apply-event :default :- models.internal.shopping-list/ShoppingList
   [{:keys [event-type]} :- models.internal.shopping-cart/CartEvent
    shopping :- models.internal.shopping-list/ShoppingList]
@@ -114,6 +122,7 @@
 (s/defn ^:private apply-events
   [[current & remaining] :- (s/maybe [models.internal.shopping-cart/CartEvent])
    shopping :- models.internal.shopping-list/ShoppingList]
+  (println current)
   (if (not current)
     shopping
     (recur remaining (apply-event current shopping))))

--- a/src/purchase_listinator/logic/shopping_cart_event.clj
+++ b/src/purchase_listinator/logic/shopping_cart_event.clj
@@ -128,7 +128,6 @@
 (s/defn ^:private apply-events
   [[current & remaining] :- (s/maybe [models.internal.shopping-cart/CartEvent])
    shopping :- models.internal.shopping-list/ShoppingList]
-  (println current)
   (if (not current)
     shopping
     (recur remaining (apply-event current shopping))))

--- a/src/purchase_listinator/logic/shopping_cart_event.clj
+++ b/src/purchase_listinator/logic/shopping_cart_event.clj
@@ -110,7 +110,7 @@
   [{:keys [category-id]} :- models.internal.shopping-cart/PurchaseListCategoryDeleted
    {:keys [categories] :as shopping} :- models.internal.shopping-list/ShoppingList]
   (->> categories
-       (filter #(not= (:id % category-id)))
+       (filter #(not= (:id %) category-id))
        (assoc shopping :categories)))
 
 (s/defmethod ^:private apply-event :purchase-list-category-created :- models.internal.shopping-list/ShoppingList

--- a/src/purchase_listinator/logic/shopping_purchase_list_cart_event.clj
+++ b/src/purchase_listinator/logic/shopping_purchase_list_cart_event.clj
@@ -1,0 +1,10 @@
+(ns purchase-listinator.logic.shopping-purchase-list-cart-event
+  (:require [schema.core :as s]
+            [purchase-listinator.models.internal.shopping-cart :as models.internal.shopping-cart]))
+
+(s/defn created->category
+  [{:keys [category-id] :as event} :- models.internal.shopping-cart/PurchaseListCategoryCreated]
+  (-> event
+      (assoc :id category-id
+             :items [])
+      (dissoc :category-id)))

--- a/src/purchase_listinator/logic/shopping_purchase_list_cart_event.clj
+++ b/src/purchase_listinator/logic/shopping_purchase_list_cart_event.clj
@@ -1,10 +1,11 @@
 (ns purchase-listinator.logic.shopping-purchase-list-cart-event
   (:require [schema.core :as s]
-            [purchase-listinator.models.internal.shopping-cart :as models.internal.shopping-cart]))
+            [purchase-listinator.models.internal.shopping-cart :as models.internal.shopping-cart]
+            [purchase-listinator.models.internal.shopping-list :as models.internal.shopping-list]))
 
-(s/defn created->category
+(s/defn created->category :- models.internal.shopping-list/ShoppingListCategory
   [{:keys [category-id] :as event} :- models.internal.shopping-cart/PurchaseListCategoryCreated]
   (-> event
       (assoc :id category-id
              :items [])
-      (dissoc :category-id)))
+      (dissoc :category-id :event-type :moment)))

--- a/src/purchase_listinator/misc/date.clj
+++ b/src/purchase_listinator/misc/date.clj
@@ -1,8 +1,13 @@
 (ns purchase-listinator.misc.date
   (:require [schema.core :as s]
             [clj-time.core :as t]
-            [clj-time.coerce :as c]))
+            [clj-time.coerce :as c])
+  (:import (java.util Date)))
 
 (s/defn numb-now :- s/Num
   []
   (c/to-long (t/now)))
+
+(s/defn numb->date :- Date
+  [num :- s/Num]
+  (c/to-date num))

--- a/src/purchase_listinator/models/internal/purchase_list.clj
+++ b/src/purchase_listinator/models/internal/purchase_list.clj
@@ -4,11 +4,11 @@
 (def Status (s/enum :in-progress :waiting))
 
 (def purchase-list-skeleton
-  {:id          s/Uuid
-   :name        s/Str
-   :enabled     s/Bool
-   :in-progress s/Bool
-   :status      Status})
+  {:id                      s/Uuid
+   :name                    s/Str
+   :enabled                 s/Bool
+   :in-progress             s/Bool
+   (s/optional-key :status) Status})
 
 (s/defschema PurchaseList purchase-list-skeleton)
 

--- a/src/purchase_listinator/models/internal/shopping_cart.clj
+++ b/src/purchase_listinator/models/internal/shopping_cart.clj
@@ -30,6 +30,15 @@
    :category-id      s/Uuid
    :purchase-list-id s/Uuid})
 
+(s/defschema PurchaseListCategoryCreated
+  {:moment           s/Num
+   :event-type       (s/eq :purchase-list-category-created)
+   :name             s/Str
+   :category-id      s/Uuid
+   :order-position   s/Int
+   :color            s/Int
+   :purchase-list-id s/Uuid})
+
 (s/defn of-type
   [expected-event-type {:keys [event-type]}]
   (= expected-event-type event-type))
@@ -37,7 +46,9 @@
 (s/defschema CartEvent
   (s/conditional
     (partial of-type :reorder-category) ReorderCategoryEvent
-    (partial of-type :reorder-item) ReorderItemEvent))
+    (partial of-type :reorder-item) ReorderItemEvent
+    (partial of-type :purchase-list-category-deleted) PurchaseListCategoryDeleted
+    (partial of-type :reorder-item) PurchaseListCategoryCreated))
 
 (def cart-skeleton
   {:shopping-id s/Uuid

--- a/src/purchase_listinator/models/internal/shopping_cart.clj
+++ b/src/purchase_listinator/models/internal/shopping_cart.clj
@@ -24,7 +24,6 @@
    :price            s/Num
    :quantity-changed s/Int})
 
-
 (s/defn of-type
   [expected-event-type {:keys [event-type]}]
   (= expected-event-type event-type))

--- a/src/purchase_listinator/models/internal/shopping_cart.clj
+++ b/src/purchase_listinator/models/internal/shopping_cart.clj
@@ -24,6 +24,12 @@
    :price            s/Num
    :quantity-changed s/Int})
 
+(s/defschema PurchaseListCategoryDeleted
+  {:moment           s/Num
+   :event-type       (s/eq :purchase-list-category-deleted)
+   :category-id      s/Uuid
+   :purchase-list-id s/Uuid})
+
 (s/defn of-type
   [expected-event-type {:keys [event-type]}]
   (= expected-event-type event-type))

--- a/src/purchase_listinator/publishers/purchase_list_category.clj
+++ b/src/purchase_listinator/publishers/purchase_list_category.clj
@@ -1,0 +1,10 @@
+(ns purchase-listinator.publishers.purchase-list-category
+  (:require [schema.core :as s]
+            [purchase-listinator.models.internal.purchase-category :as models.internal.purchase-category]
+            [purchase-listinator.adapters.out.purchase-list-category-events :as adapters.out.purchase-list-category-events]))
+
+(s/defn category-deleted
+  [category :- models.internal.purchase-category/PurchaseCategory
+   {:keys [publish]}]
+  (publish :purchase-listinator/purchase-list.category.deleted
+           (adapters.out.purchase-list-category-events/->CategoryDeletedEvent category)))

--- a/src/purchase_listinator/publishers/purchase_list_category.clj
+++ b/src/purchase_listinator/publishers/purchase_list_category.clj
@@ -9,3 +9,10 @@
    {:keys [publish]}]
   (publish :purchase-listinator/purchase-list.category.deleted
            (adapters.out.purchase-list-category-events/->CategoryDeletedEvent category (misc.date/numb-now))))
+
+(s/defn category-created
+  [category :- models.internal.purchase-category/PurchaseCategory
+   {:keys [publish]}]
+  (publish :purchase-listinator/purchase-list.category.created
+           (adapters.out.purchase-list-category-events/->CategoryCreatedEvent category (misc.date/numb-now))))
+

--- a/src/purchase_listinator/publishers/purchase_list_category.clj
+++ b/src/purchase_listinator/publishers/purchase_list_category.clj
@@ -1,10 +1,11 @@
 (ns purchase-listinator.publishers.purchase-list-category
   (:require [schema.core :as s]
             [purchase-listinator.models.internal.purchase-category :as models.internal.purchase-category]
-            [purchase-listinator.adapters.out.purchase-list-category-events :as adapters.out.purchase-list-category-events]))
+            [purchase-listinator.adapters.out.purchase-list-category-events :as adapters.out.purchase-list-category-events]
+            [purchase-listinator.misc.date :as misc.date]))
 
 (s/defn category-deleted
   [category :- models.internal.purchase-category/PurchaseCategory
    {:keys [publish]}]
   (publish :purchase-listinator/purchase-list.category.deleted
-           (adapters.out.purchase-list-category-events/->CategoryDeletedEvent category)))
+           (adapters.out.purchase-list-category-events/->CategoryDeletedEvent category (misc.date/numb-now))))

--- a/src/purchase_listinator/wires/in/purchase_category_events.clj
+++ b/src/purchase_listinator/wires/in/purchase_category_events.clj
@@ -1,0 +1,8 @@
+(ns purchase-listinator.wires.in.purchase-category-events
+  (:require [schema.core :as s]))
+
+(def purchase-category-deleted-event-skeleton
+  {:category-id      s/Uuid
+   :purchase-list-id s/Uuid})
+
+(s/defschema PurchaseCategoryDeletedEvent purchase-category-deleted-event-skeleton)

--- a/src/purchase_listinator/wires/in/purchase_category_events.clj
+++ b/src/purchase_listinator/wires/in/purchase_category_events.clj
@@ -3,6 +3,7 @@
 
 (def purchase-category-deleted-event-skeleton
   {:category-id      s/Uuid
-   :purchase-list-id s/Uuid})
+   :purchase-list-id s/Uuid
+   :moment           s/Num})
 
 (s/defschema PurchaseCategoryDeletedEvent purchase-category-deleted-event-skeleton)

--- a/src/purchase_listinator/wires/in/purchase_category_events.clj
+++ b/src/purchase_listinator/wires/in/purchase_category_events.clj
@@ -5,5 +5,13 @@
   {:category-id      s/Uuid
    :purchase-list-id s/Uuid
    :moment           s/Num})
-
 (s/defschema PurchaseCategoryDeletedEvent purchase-category-deleted-event-skeleton)
+
+(def purchase-category-created-event-skeleton
+  {:name             s/Str
+   :category-id      s/Uuid
+   :order-position   s/Int
+   :color            s/Int
+   :purchase-list-id s/Uuid
+   :moment           s/Num})
+(s/defschema PurchaseCategoryCreatedEvent purchase-category-created-event-skeleton)

--- a/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
+++ b/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
@@ -3,6 +3,7 @@
 
 (def purchase-category-deleted-event-skeleton
   {:category-id      s/Uuid
-   :purchase-list-id s/Uuid})
+   :purchase-list-id s/Uuid
+   :moment           s/Num})
 
 (s/defschema CategoryDeletedEvent purchase-category-deleted-event-skeleton)

--- a/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
+++ b/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
@@ -7,3 +7,13 @@
    :moment           s/Num})
 
 (s/defschema CategoryDeletedEvent purchase-category-deleted-event-skeleton)
+
+(def purchase-category-created-event-skeleton
+  {:name             s/Str
+   :category-id      s/Uuid
+   :order-position   s/Int
+   :color            s/Int
+   :purchase-list-id s/Uuid
+   :moment           s/Num})
+
+(s/defschema CategoryCreatedEvent purchase-category-created-event-skeleton)

--- a/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
+++ b/src/purchase_listinator/wires/out/purchase_list_caegory_events.clj
@@ -1,0 +1,8 @@
+(ns purchase-listinator.wires.out.purchase-list-caegory-events
+  (:require [schema.core :as s]))
+
+(def purchase-category-deleted-event-skeleton
+  {:category-id      s/Uuid
+   :purchase-list-id s/Uuid})
+
+(s/defschema CategoryDeletedEvent purchase-category-deleted-event-skeleton)

--- a/src/purchase_listinator/wires/out/purchase_list_category_events.clj
+++ b/src/purchase_listinator/wires/out/purchase_list_category_events.clj
@@ -1,4 +1,4 @@
-(ns purchase-listinator.wires.out.purchase-list-caegory-events
+(ns purchase-listinator.wires.out.purchase-list-category-events
   (:require [schema.core :as s]))
 
 (def purchase-category-deleted-event-skeleton

--- a/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
+++ b/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
@@ -87,7 +87,7 @@
 (st/deftest apply-event-purchase-list-category-created-test
   (testing "Should add a category in the shopping when processing a category created event"
     (let [{:keys [categories]} (logic.shopping-cart-event/apply-event purchase-list-category-created-event shopping-list)]
-      (is (= 2 (count categories)))
+      (is (= 3 (count categories)))
       (is (= {:name             "New category"
               :id               new-category-id
               :order-position   50

--- a/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
+++ b/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
@@ -88,3 +88,24 @@
             event (assoc change-item-event :price 50.30)]
         (is (= expected-shopping
                (logic.shopping-cart-event/apply-event event shopping-list)))))))
+
+(def new-category-id (random-uuid))
+(def purchase-list-category-created-event
+  {:moment           123
+   :event-type       :purchase-list-category-created
+   :name             "New category"
+   :category-id      new-category-id
+   :order-position   50
+   :color            321
+   :purchase-list-id purchase-list-id})
+
+(st/deftest apply-event-purchase-list-category-created-test
+  (testing "Should add a category in the shopping when processing a category created event"
+    (let [{:keys [categories]} (logic.shopping-cart-event/apply-event purchase-list-category-created-event shopping-list)]
+      (is (= 2 (count categories)))
+      (is (= {:name             "New category"
+              :id               new-category-id
+              :order-position   50
+              :color            321
+              :purchase-list-id purchase-list-id
+              :items            []} (last categories))))))

--- a/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
+++ b/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
@@ -1,11 +1,13 @@
 (ns purchase-listinator.logic.shopping-cart-event-test
   (:require [clojure.test :refer :all]
             [purchase-listinator.logic.shopping-cart-event :as logic.shopping-cart-event]
-            [schema.test :as st]))
+            [schema.test :as st]
+            [schema.core :as s]))
 
 (def purchase-list-id (random-uuid))
 (def shopping-id (random-uuid))
 (def category-id (random-uuid))
+(def category2-id (random-uuid))
 (def item-id (random-uuid))
 
 (def item1
@@ -25,10 +27,16 @@
    :purchase-list-id purchase-list-id
    :items            [item1]})
 
+(def category2
+  (assoc category1 :id category2-id
+                   :name "Category 2"
+                   :items []
+                   :order-position 2))
+
 (def shopping-list
   {:purchase-list-id purchase-list-id
    :shopping-id      shopping-id
-   :categories       [category1]})
+   :categories       [category1 category2]})
 
 (def change-item-event
   {:moment           123
@@ -46,45 +54,23 @@
    :price            0
    :quantity-changed -5})
 
-(def expected-item1
-  {:id               item-id
-   :name             "item"
-   :quantity         15
-   :price            0
-   :quantity-in-cart 10
-   :order-position   0
-   :category-id      category-id})
-
-(def expected-category1
-  {:name             "Category 1"
-   :id               category-id
-   :order-position   1
-   :color            123
-   :purchase-list-id purchase-list-id
-   :items            [expected-item1]})
-
-(def expected-shopping-list
-  {:purchase-list-id purchase-list-id
-   :shopping-id      shopping-id
-   :categories       [expected-category1]})
-
 (st/deftest apply-event-change-item-test
   (testing "Should change an item in the cart"
     (testing "When adding items in the cart"
-      (is (= expected-shopping-list
+      (is (= (assoc-in shopping-list [:categories 0 :items 0 :quantity-in-cart] 10)
              (logic.shopping-cart-event/apply-event change-item-event shopping-list))))
     (testing "When removing items in the cart"
       (let [shopping (assoc-in shopping-list [:categories 0 :items 0 :quantity-in-cart] 5)
-            expected-shopping (assoc-in expected-shopping-list [:categories 0 :items 0 :quantity-in-cart] 0)]
+            expected-shopping (assoc-in shopping-list [:categories 0 :items 0 :quantity-in-cart] 0)]
         (is (= expected-shopping
                (logic.shopping-cart-event/apply-event change-item-removing-event shopping)))))
     (testing "When adding more items in the cart"
       (let [shopping (assoc-in shopping-list [:categories 0 :items 0 :quantity-in-cart] 5)
-            expected-shopping (assoc-in expected-shopping-list [:categories 0 :items 0 :quantity-in-cart] 15)]
+            expected-shopping (assoc-in shopping-list [:categories 0 :items 0 :quantity-in-cart] 15)]
         (is (= expected-shopping
                (logic.shopping-cart-event/apply-event change-item-event shopping)))))
     (testing "When changing the price of the item"
-      (let [expected-shopping (assoc-in expected-shopping-list [:categories 0 :items 0 :price] 50.30)
+      (let [expected-shopping (update-in shopping-list [:categories 0 :items 0] assoc :price 50.30 :quantity-in-cart 10)
             event (assoc change-item-event :price 50.30)]
         (is (= expected-shopping
                (logic.shopping-cart-event/apply-event event shopping-list)))))))
@@ -109,3 +95,15 @@
               :color            321
               :purchase-list-id purchase-list-id
               :items            []} (last categories))))))
+
+
+(def purchase-list-category-deleted-event
+  {:moment           213
+   :event-type       :purchase-list-category-deleted
+   :category-id      category-id
+   :purchase-list-id purchase-list-id})
+
+(st/deftest apply-event-purchase-list-category-deleted-test
+  (testing "Should remove the category in the shopping when processing a category deleted event"
+    (let [{:keys [categories]} (logic.shopping-cart-event/apply-event purchase-list-category-deleted-event shopping-list)]
+      (is (= 1 (count categories))))))

--- a/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
+++ b/test/unit/purchase_listinator/logic/shopping_cart_event_test.clj
@@ -1,8 +1,7 @@
 (ns purchase-listinator.logic.shopping-cart-event-test
   (:require [clojure.test :refer :all]
             [purchase-listinator.logic.shopping-cart-event :as logic.shopping-cart-event]
-            [schema.test :as st]
-            [schema.core :as s]))
+            [schema.test :as st]))
 
 (def purchase-list-id (random-uuid))
 (def shopping-id (random-uuid))
@@ -95,7 +94,6 @@
               :color            321
               :purchase-list-id purchase-list-id
               :items            []} (last categories))))))
-
 
 (def purchase-list-category-deleted-event
   {:moment           213


### PR DESCRIPTION
Receiving two events from purchase list domain and inserting them in the cart:
- Category created
- Category deleted

Getting a purchase list from datomic at the moment the shopping is created and applying all the events on it since them

Coercing data directly in the consumer

References:
https://github.com/gumberss/PurchaseListinator/issues/62 https://github.com/gumberss/PurchaseListinator/issues/63 https://github.com/gumberss/PurchaseListinator/issues/64 https://github.com/gumberss/PurchaseListinator/issues/65 https://github.com/gumberss/PurchaseListinator/issues/66